### PR TITLE
Create a `.devcontainer` config for local development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/vscode/devcontainers/go:1.18-bullseye
+
+RUN apt update \
+    && apt upgrade -y
+
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,3 +7,6 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 
 # Delve for debugging
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+# goimports for source formatting
+RUN go install golang.org/x/tools/cmd/goimports@latest

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,3 +4,6 @@ RUN apt update \
     && apt upgrade -y
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s 
+
+# Delve for debugging
+RUN go install github.com/go-delve/delve/cmd/dlv@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"go.formatTool": "goimports",
+		"editor.formatOnSave": true
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go",
+		"mhutchie.git-graph",
+		"ms-vscode.makefile-tools"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		1927
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+ENTRYPOINT:=cmd/api/main.go
 BIN:=core-api
 
 .PHONY: test
@@ -10,7 +11,7 @@ test-ci:
 
 .PHONY: build
 build:
-	go build -o $(BIN) ./cmd/api/main.go
+	go build -o $(BIN) $(ENTRYPOINT)
 
 # ensures that dependencies have been tidied and vendored
 .PHONY: ensure-deps
@@ -27,3 +28,7 @@ fmt-deps:
 .PHONY: fmt
 fmt: fmt-deps
 	@goimports -w cmd/ internal/
+
+.PHONY: debug
+debug:
+	@dlv debug $(ENTRYPOINT)

--- a/README.md
+++ b/README.md
@@ -20,16 +20,33 @@ To get started:
 
 ### Non-Docker/VSCode
 
-1. Install Go 1.18: https://go.dev/doc/install and verify your installation by running `go version`.
+1. Install [Go 1.18](https://go.dev/doc/install) and verify your installation by running `go version`.
+2. Install [golangci-lint](https://golangci-lint.run/usage/install/#local-installation).
+3. Install [Delve](https://github.com/go-delve/delve/tree/master/Documentation/installation).
 2. Clone the repo.
-3. Run `make build && ./core-api` to start the server.
+
+## Development
+
+### Run
+
+1. Run `make build` to produce the executable binary.
+2. Run `./core-api` to start the server.
+
+### Test
+
+1. Run `make test` to execute Go tests.
+
+### Debug
+
+1. Run `make debug` to debug the server. You can alternatively use the debugging capabilities provided by your editor.
 
 ## Directories
+
 * `cmd/` - This is where the entrypoint into the application is (at `api/main.go`)
 * `internal/` - This is where the routes of the server are defined. They are then imported into the main application in `cmd/api/main.go`
 
 Currently there are only 2 routes defined, `/` and `/ping`.
 
-
 ## Other things of interest
+
 * This project uses Go modules for dependency management, take a look at the files `go.mod`, `go.sum`, and the directory `vendor/`. You can learn a bit more about Go modules here: [DigitalOcean Go Modules Introduction](https://www.digitalocean.com/community/tutorials/how-to-use-go-modules), [Go Blog Official Go Modules Intro](https://go.dev/blog/using-go-modules).

--- a/README.md
+++ b/README.md
@@ -3,10 +3,26 @@
 Go project using Gin router - https://github.com/gin-gonic/gin
 
 ## Setup
-1. Install Go: https://go.dev/doc/install
-2. Clone the repo
-3. Run `go run cmd/api/main.go`
 
+### VSCode fast-path
+
+This project includes a [.devcontainers](https://code.visualstudio.com/docs/remote/containers) configuration
+that can be used by VSCode to create a one-click development environment with Docker. The Docker container
+includes all of the dependencies you need to compile Go, forwards the port exposed by HTTP server to your
+local machine, and mounts the repository into the container so changes persist outside of Docker.
+
+To get started:
+
+1. Install the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+   VSCode extension.
+2. Open the repository with VSCode. You should see a prompt on the bottom left of the screen to open the
+   project inside the container.
+
+### Non-Docker/VSCode
+
+1. Install Go 1.18: https://go.dev/doc/install and verify your installation by running `go version`.
+2. Clone the repo.
+3. Run `make build && ./core-api` to start the server.
 
 ## Directories
 * `cmd/` - This is where the entrypoint into the application is (at `api/main.go`)
@@ -17,4 +33,3 @@ Currently there are only 2 routes defined, `/` and `/ping`.
 
 ## Other things of interest
 * This project uses Go modules for dependency management, take a look at the files `go.mod`, `go.sum`, and the directory `vendor/`. You can learn a bit more about Go modules here: [DigitalOcean Go Modules Introduction](https://www.digitalocean.com/community/tutorials/how-to-use-go-modules), [Go Blog Official Go Modules Intro](https://go.dev/blog/using-go-modules).
-* 


### PR DESCRIPTION
This PR adds a `devcontainer` config for local development. It uses the Go 1.18 bullseye (Debian) base image for ARM compatibility.