### PR TITLE
fix: change port to avoid conflict with frontend

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -11,5 +11,5 @@ func main() {
 	router.GET("/", api.Index)
 	router.GET("/ping", api.Ping)
 
-	_ = router.Run(":3000")
+	_ = router.Run(":1927")
 }


### PR DESCRIPTION
The NextJS dev server listens on port 3000. This commit changes the port
binding for the backend to 8080 so both services can be run on the same
machine simultaneously.