### PR TITLE
Shutdown gracefully via signal interrupt

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,13 +1,35 @@
 package main
 
 import (
+	"context"
+	"log"
+	"net/http"
 	"omshub/core-api/internal/api"
+	"os/signal"
+	"syscall"
 )
 
 func main() {
-	server := api.NewServer(api.Config{
-		Port: "1927",
-	})
+	// TODO: read from file or env vars
+	config := api.DefaultConfig()
+	server := api.NewServer(config)
 
-	_ = server.Serve()
+	go func() {
+		if err := server.Serve(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("[error] serve: %s\n", err)
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	<-ctx.Done()
+
+	stop()
+
+	log.Println("[info] shutting down")
+
+	if err := server.Shutdown(); err != nil {
+		log.Fatalf("[error] shutdown: %s\n", err)
+	}
 }

--- a/internal/api/base.go
+++ b/internal/api/base.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -39,7 +38,7 @@ func (s *Server) Serve() error {
 }
 
 func (s *Server) Shutdown() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), s.config.ShutdownDuration)
 	defer cancel()
 
 	return s.httpServer.Shutdown(ctx)

--- a/internal/api/base.go
+++ b/internal/api/base.go
@@ -38,7 +38,7 @@ func (s *Server) Serve() error {
 }
 
 func (s *Server) Shutdown() error {
-	ctx, cancel := context.WithTimeout(context.Background(), s.config.ShutdownDuration)
+	ctx, cancel := context.WithTimeout(context.Background(), s.config.ShutdownTimeout)
 	defer cancel()
 
 	return s.httpServer.Shutdown(ctx)

--- a/internal/api/base_test.go
+++ b/internal/api/base_test.go
@@ -39,9 +39,7 @@ func TestPing(t *testing.T) {
 }
 
 func testServer(t *testing.T) func() {
-	server := NewServer(Config{
-		Port: "1927",
-	})
+	server := NewServer(DefaultConfig())
 
 	go func() {
 		_ = server.Serve()

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -1,5 +1,16 @@
 package api
 
+import "time"
+
 type Config struct {
-	Port string
+	Port             string
+	ShutdownDuration time.Duration
+}
+
+// TODO: use a library to manage sensible defaults via struct tags
+func DefaultConfig() Config {
+	return Config{
+		Port:             "1927",
+		ShutdownDuration: time.Second * 5,
+	}
 }

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -3,14 +3,14 @@ package api
 import "time"
 
 type Config struct {
-	Port             string
-	ShutdownDuration time.Duration
+	Port            string
+	ShutdownTimeout time.Duration
 }
 
 // TODO: use a library to manage sensible defaults via struct tags
 func DefaultConfig() Config {
 	return Config{
-		Port:             "1927",
-		ShutdownDuration: time.Second * 5,
+		Port:            "1927",
+		ShutdownTimeout: time.Second * 5,
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/omshub/core-api/issues/6

Also removed hardcoded timeout for shutdown (5 seconds), and added `DefaultConfig` for sensible defaults. In the future we should use struct tags for defaults (should be covered by https://github.com/omshub/core-api/issues/11).