### PR TITLE
ci: use api.omshub.org as the domain for the DO app

### DIFF
--- a/ops/main.tf
+++ b/ops/main.tf
@@ -28,6 +28,12 @@ resource "digitalocean_app" "app_core_api" {
     name   = "core-api"
     region = "nyc"
 
+    # CNAME record needs to be manually configured in Google Domains
+    # to route to the do_app_url TF output var.
+    domain {
+      name = "api.omshub.org"
+    }
+
     service {
       name               = "core-api"
       instance_count     = 1


### PR DESCRIPTION
Adds a domain configuration to the DO app which enables us to add a
CNAME record in Google Domains to route api.omshub.org to the Go
service.

Currently, the CNAME record needs to be manually set.
https://github.com/omshub/core-api/issues/16#issuecomment-1129642799
outlines some advantages of Cloudflare which we can opt to use later
down the track.