### PR TITLE
fix: install deps on startup to fix perm issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,11 +2,3 @@ FROM mcr.microsoft.com/vscode/devcontainers/go:1.18-bullseye
 
 RUN apt update \
     && apt upgrade -y
-
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s 
-
-# Delve for debugging
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
-
-# goimports for source formatting
-RUN go install golang.org/x/tools/cmd/goimports@latest

--- a/.devcontainer/auto-setup.sh
+++ b/.devcontainer/auto-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# golangci-lint for debugging linting issues locally
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s 
+
+# Delve for debugging
+go install github.com/go-delve/delve/cmd/dlv@latest
+
+# goimports for source formatting
+go install golang.org/x/tools/cmd/goimports@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,5 +32,8 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "go version",
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	// Running the commands in the script as part of the Dockerfile causes permissions issues
+	// with the /go/pkg directory.
+	"postStartCommand": "./.devcontainer/auto-setup.sh"
 }


### PR DESCRIPTION
Moves the commands to install deps like delve and golangci-lint to a
helper script to fix a problem with permissions on the /go/pkg
directory. Running the same commands within the Dockerfile would cause
the /go/pkg directory to be owned by root, preventing Go modules from
being installed by the `vscode` user.