### PR TITLE
fix: copy config.yml to runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ WORKDIR /root/
 
 COPY --from=builder /app/core-api /usr/local/bin/
 
+COPY config.yml config.yml
+
 CMD ["core-api"]


### PR DESCRIPTION
The configuration file wasn't being copied to the runtime container,
causing the app to panic when it tried to read the YAML config on
startup.